### PR TITLE
chore(deps): remove deprecated @types/marked stub

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "tailwindcss": "3.4.3"
   },
   "devDependencies": {
-    "@types/marked": "6.0.0",
     "husky": "9.0.11",
     "prettier": "3.2.5",
     "prettier-plugin-astro": "0.13.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ importers:
         specifier: 3.4.3
         version: 3.4.3
     devDependencies:
-      '@types/marked':
-        specifier: 6.0.0
-        version: 6.0.0
       husky:
         specifier: 9.0.11
         version: 9.0.11
@@ -580,10 +577,6 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
-  '@types/marked@6.0.0':
-    resolution: {integrity: sha512-jmjpa4BwUsmhxcfsgUit/7A9KbrC48Q0q8KvnY107ogcjGgTFDlIL3RpihNpx2Mu1hM4mdFQjoVc4O6JoGKHsA==}
-    deprecated: This is a stub types definition. marked provides its own type definitions, so you do not need this installed.
 
   '@types/mdast@4.0.3':
     resolution: {integrity: sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==}
@@ -2648,10 +2641,6 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.2
-
-  '@types/marked@6.0.0':
-    dependencies:
-      marked: 12.0.2
 
   '@types/mdast@4.0.3':
     dependencies:


### PR DESCRIPTION
Fixed warning
```
 WARN  deprecated @types/marked@6.0.0: This is a stub types definition. marked provides its own type definitions, so you do not need this installed.
```