### PR TITLE
docs: update tools order

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,26 +15,25 @@ const openSourceLibs = [
     link: 'https://reactjs.org/',
     image: import('../assets/logos/react.png'),
   },
-
-  {
-    name: 'Typescript',
-    link: 'https://www.typescriptlang.org/',
-    image: import('../assets/logos/typescript.png'),
-  },
   {
     name: 'Tailwind CSS',
     link: 'https://tailwindcss.com/',
     image: import('../assets/logos/tailwindcss.png'),
   },
   {
-    name: 'GitHub',
-    link: 'https://www.github.com/',
-    image: import('../assets/logos/github.png'),
-  },
-  {
     name: 'Jest',
     link: 'https://jestjs.io/',
     image: import('../assets/logos/jest.png'),
+  },
+  {
+    name: 'Typescript',
+    link: 'https://www.typescriptlang.org/',
+    image: import('../assets/logos/typescript.png'),
+  },
+  {
+    name: 'GitHub',
+    link: 'https://www.github.com/',
+    image: import('../assets/logos/github.png'),
   },
 ];
 ---
@@ -45,7 +44,7 @@ const openSourceLibs = [
 
     <SectionRow
       title="All your GitHub notifications on your desktop. Nice & Easy."
-      description="Ever got lost with GitHub notifications? Too many emails? Gitify is all about making your life easier. Sitting on your menu bar, it informs you for any GitHub notifications without being annoying and of course without adverts. It just gets the job done. Works with GitHub and GitHub Enterprise. You can even connect **multiple** accounts."
+      description="Ever got lost with GitHub notifications? Too many emails? Gitify is all about making your life easier. Sitting on your menu bar, it informs you for any GitHub notifications without being annoying and of course without adverts. It just gets the job done. Works with GitHub Cloud and GitHub Enterprise Server. You can even connect **multiple** accounts."
       screenshot={{
         path: 'all-read',
         alt: 'Screenshot when there are no notifications read',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -44,7 +44,7 @@ const openSourceLibs = [
 
     <SectionRow
       title="All your GitHub notifications on your desktop. Nice & Easy."
-      description="Ever got lost with GitHub notifications? Too many emails? Gitify is all about making your life easier. Sitting on your menu bar, it informs you for any GitHub notifications without being annoying and of course without adverts. It just gets the job done. Works with GitHub Cloud and GitHub Enterprise Server. You can even connect **multiple** accounts."
+      description="Ever got lost with GitHub notifications? Too many emails? Gitify is all about making your life easier. Sitting on your menu bar, it informs you for any GitHub notifications without being annoying and of course without adverts. It just gets the job done. Works with GitHub and GitHub Enterprise. You can even connect **multiple** accounts."
       screenshot={{
         path: 'all-read',
         alt: 'Screenshot when there are no notifications read',


### PR DESCRIPTION
Icon order now matches the description order. 

Also when rendered on mobile it looks better with GitHub icon overflowing to its own row