### PR TITLE
feat: download links primary vs alternate

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@kobalte/core": "0.13.6",
     "@tailwindcss/typography": "0.5.15",
     "astro": "4.15.9",
-    "bowser": "2.11.0",
     "class-variance-authority": "0.7.0",
     "clsx": "2.1.1",
     "date-fns": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       astro:
         specifier: 4.15.9
         version: 4.15.9(rollup@4.21.2)(typescript@5.5.4)
-      bowser:
-        specifier: 2.11.0
-        version: 2.11.0
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
@@ -875,9 +872,6 @@ packages:
   binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
-
-  bowser@2.11.0:
-    resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
 
   boxen@7.1.1:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
@@ -3205,8 +3199,6 @@ snapshots:
   base-64@1.0.0: {}
 
   binary-extensions@2.2.0: {}
-
-  bowser@2.11.0: {}
 
   boxen@7.1.1:
     dependencies:

--- a/src/components/LatestRelease.astro
+++ b/src/components/LatestRelease.astro
@@ -1,5 +1,4 @@
 ---
-import Bowser from 'bowser';
 import { format, parseISO } from 'date-fns';
 import { siteMetadata } from '~/constants';
 import DownloadIcon from '../icons/Download.astro';
@@ -20,16 +19,19 @@ const getDownloadLinks = (assets: Assets[]): DownloadLinks => {
       os: 'macOS',
       name: 'macOS (Universal)',
       url: getAssetLink(/Gitify-\d+.\d+.\d+-universal.dmg/g),
+      isPrimary: true,
     },
     {
       os: 'Windows',
       name: 'Windows',
       url: getAssetLink(/Gitify-Setup-\d+.\d+.\d+.exe/g),
+      isPrimary: true,
     },
     {
       os: 'Linux',
       name: 'Linux (AppImage)',
       url: getAssetLink(/Gitify-\d+.\d+.\d+.AppImage/g),
+      isPrimary: true,
     },
     {
       os: 'Linux',
@@ -43,22 +45,19 @@ const getDownloadLinks = (assets: Assets[]): DownloadLinks => {
     },
   ];
 
-  const isWindowAvailable = typeof window !== 'undefined' && window.navigator;
-  const currentOs = isWindowAvailable
-    ? Bowser.parse(window.navigator.userAgent).os.name
-    : 'macOS'; // macOS, Windows, Linux
-
-  const primaryLinks = supportedOSs.filter(
-    ({ os, url }) => url && os === currentOs,
+  const primaryDownloadLinks = supportedOSs.filter(
+    ({ isPrimary, url }) => url && isPrimary,
   );
-  const primaryLinksOSs = primaryLinks.map(({ os }) => os);
-  const alt = supportedOSs.filter(
-    ({ os, url }) => !primaryLinksOSs.includes(os) && url,
+
+  const altDownloadLinks = supportedOSs.filter(
+    ({ isPrimary, url }) => url && !isPrimary,
   );
 
   return {
-    primary: primaryLinks.length ? primaryLinks : [supportedOSs[0]],
-    alt,
+    primary: primaryDownloadLinks.length
+      ? primaryDownloadLinks
+      : [supportedOSs[0]],
+    alt: altDownloadLinks,
   };
 };
 
@@ -108,13 +107,16 @@ const { downloadLinks, version, releaseDate } = await loadInitialData();
           <p>Released on {releaseDate}.</p>
           {downloadLinks.alt.length > 0 && (
             <p>
-              Also available on{' '}
-              {downloadLinks.alt.map((platform, index) => (
-                <a href={platform.url || REPO_RELEASES_URL}>
-                  {platform.name +
-                    (index < downloadLinks.alt.length - 1 ? ', ' : '.')}
-                </a>
-              ))}
+              Also available on:
+                <ul class="list-disc list-inside ml-4">
+                  {downloadLinks.alt.map((platform, index) => (
+                    <li>
+                      <a href={platform.url || REPO_RELEASES_URL} class="hover:text-blue-600 hover:underline">
+                        {platform.name}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
             </p>
           )}
         </div>

--- a/src/components/LatestRelease.astro
+++ b/src/components/LatestRelease.astro
@@ -17,19 +17,9 @@ const getDownloadLinks = (assets: Assets[]): DownloadLinks => {
   const supportedOSs: DownloadLink[] = [
     {
       os: 'macOS',
-      name: 'macOS (Apple Silicon)',
-      url: getAssetLink(/Gitify-\d+.\d+.\d+-arm64.dmg/g),
-      isPrimary: true,
-    },
-    {
-      os: 'macOS',
-      name: 'macOS (Intel)',
-      url: getAssetLink(/Gitify-\d+.\d+.\d+.dmg/g),
-    },
-    {
-      os: 'macOS',
       name: 'macOS (Universal)',
       url: getAssetLink(/Gitify-\d+.\d+.\d+-universal.dmg/g),
+      isPrimary: true,
     },
     {
       os: 'Windows',

--- a/src/components/LatestRelease.astro
+++ b/src/components/LatestRelease.astro
@@ -17,9 +17,19 @@ const getDownloadLinks = (assets: Assets[]): DownloadLinks => {
   const supportedOSs: DownloadLink[] = [
     {
       os: 'macOS',
+      name: 'macOS (Apple Silicon)',
+      url: getAssetLink(/Gitify-\d+.\d+.\d+-arm64.dmg/g),
+      isPrimary: true,
+    },
+    {
+      os: 'macOS',
+      name: 'macOS (Intel)',
+      url: getAssetLink(/Gitify-\d+.\d+.\d+.dmg/g),
+    },
+    {
+      os: 'macOS',
       name: 'macOS (Universal)',
       url: getAssetLink(/Gitify-\d+.\d+.\d+-universal.dmg/g),
-      isPrimary: true,
     },
     {
       os: 'Windows',

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface DownloadLink {
   os: string;
   name: string;
   url: string;
+  isPrimary?: boolean;
 }
 
 export interface DownloadLinks {


### PR DESCRIPTION
closes #201 

Updates the Download Latest section to show the primary option for each OS, along with alternates 

| Before | After |
| -- | -- |
| ![Screenshot 2024-09-30 at 3 50 48 PM](https://github.com/user-attachments/assets/aaee81dc-42a7-4a6c-b26c-59ecf674ef38) |  ![Screenshot 2024-09-30 at 7 02 32 PM](https://github.com/user-attachments/assets/88b419e2-b833-4a68-bc0c-5bf7a9c65a47) |

