### PR TITLE
Org team is 404 for non-members, use /people link instead

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,7 +9,7 @@ export const siteMetadata = {
   },
   author: {
     name: 'Gitify Team',
-    site: 'https://github.com/orgs/gitify-app/teams/gitify-core',
+    site: 'https://github.com/orgs/gitify-app/people',
   },
   keywords:
     'gitify,desktop,application,github,notifications,unread,menu bar,electron,open source,mac,windows,linux',


### PR DESCRIPTION
The [Gitify Team](https://github.com/orgs/gitify-app/teams/gitify-core) link will 404 for non-members. Suggesting https://github.com/orgs/gitify-app/people as an approximate alternative public link.